### PR TITLE
Port of CTRE to v3.7.1

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: ctre
-version: 3.7.0
+version: 3.7.1
 summary: Fast compile-time regular expressions with support for matching/searching/capturing during compile-time or runtime.
 license: Apache-2.0         ; Apache License 2.0
 description-file: README.md


### PR DESCRIPTION
[ci](https://ci.cppget.org/@57bd888d-776f-48eb-a5f5-6380dd688466)